### PR TITLE
fix: remove default export for typeAnimation

### DIFF
--- a/example/components/index.js
+++ b/example/components/index.js
@@ -48,4 +48,4 @@ const TypeAnimation = ({
   return <Wrapper className={finalClassName} ref={typeRef} />;
 };
 
-export default memo(TypeAnimation);
+export memo(TypeAnimation);

--- a/src/components/TypeAnimation/index.tsx
+++ b/src/components/TypeAnimation/index.tsx
@@ -182,6 +182,6 @@ const TypeAnimation: React.FC<TypeAnimationProps &
   return <Wrapper style={style} className={finalClassName} ref={typeRef} />;
 };
 
-export default memo(TypeAnimation, (_, __) => {
+export memo(TypeAnimation, (_, __) => {
   return true; // IMMUTABLE
 });

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,1 @@
-export { default as TypeAnimation } from './TypeAnimation';
+export { TypeAnimation } from './TypeAnimation';


### PR DESCRIPTION
I've created this PR to remove the default export because it is broken the build. I've tested this in a web development hosted in Netlify and the build failed.

But also, I think doesn't make sense when the import specified in README is as follow (new version):

```
import { TypeAnimation } from 'react-type-animation';
```

For those issues, I consider this PR as an improvement, 

Let me know what do you think. Thank you!