### PR TITLE
chore: removing outdated --save

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A customizable React typing animation component.
 ## Installation
 
 ```bash
-npm install --save react-type-animation
+npm install react-type-animation
 ```
 
 Requires a `react` and `react-dom` version of at least 15.0.0.


### PR DESCRIPTION
Since NPM 5.0 `--save` is default (https://blog.npmjs.org/post/161081169345/v500) and therefore not required in any installation call. 

Therefore removing the `--save` is safe to do, especially since this change occurred over 5 years ago; it is safe to assume no one needs it anymore.